### PR TITLE
fix: correct syntax for custom dark theme variant in globals.css

### DIFF
--- a/assets/css/globals.css
+++ b/assets/css/globals.css
@@ -19,7 +19,7 @@
    --LIGHT-primary-border-color: #A6A6A6;
 }
 
-/* @custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *)); */
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
 
 @theme {
    /* ==========[ BREAKPOINTS ]========== */


### PR DESCRIPTION
This pull request includes a small change to the `assets/css/globals.css` file. The change re-enables a custom variant for the dark theme by uncommenting the relevant line of code.