### PR TITLE
Section label

### DIFF
--- a/assets/css/globals.css
+++ b/assets/css/globals.css
@@ -47,6 +47,7 @@
    --color-third-color: var(--third-text-color);
    --color-fourth-color: var(--fourth-text-color);
 
+   --text-4\.5xl: 2.5rem; /* 40px */
    --text-6\.5xl: 4rem;
    --text-10xl: 9rem;
    --text-11xl: 10rem;

--- a/components/atoms/shared/Line-Primary.vue
+++ b/components/atoms/shared/Line-Primary.vue
@@ -1,3 +1,32 @@
 <template>
-  <div class="w-full h-0.5 bg-gradient-to-r from-0% from-transparent via-50% via-primary-border to-100% to-transparent" />
+  <div
+    v-if="$props.direction === 'both'"
+    class="via-primary-border w-full bg-gradient-to-r from-transparent from-0% via-50% to-transparent to-100%"
+    :style="`height: ${borderWidth}px;`"
+  />
+
+  <div
+    v-if="$props.direction === 'right'"
+    class="from-primary-border w-full bg-gradient-to-r from-80% to-transparent to-100%"
+    :style="`height: ${borderWidth}px;`"
+  />
+
+  <div
+    v-if="$props.direction === 'left'"
+    class="w-full bg-gradient-to-l from-primary-border from-80% to-transparent to-100%"
+    :style="`height: ${borderWidth}px;`"
+  />
 </template>
+
+<script lang="ts" setup>
+withDefaults(
+  defineProps<{
+    direction?: "right" | "left" | "both";
+    borderWidth?: number;
+  }>(),
+  {
+    direction: "both",
+    borderWidth: 1,
+  },
+);
+</script>

--- a/components/atoms/shared/Text_SectionLabel.vue
+++ b/components/atoms/shared/Text_SectionLabel.vue
@@ -1,3 +1,3 @@
 <template>
-  <p class="font-FiraCode flex text-primary-color text-2xl font-semibold sm:text-4xl">> <slot /></p>
+  <p class="font-FiraCode text-nowrap flex text-primary-color text-2xl font-semibold sm:text-4.5xl">> <slot /></p>
 </template>

--- a/components/atoms/shared/Text_SectionLabel.vue
+++ b/components/atoms/shared/Text_SectionLabel.vue
@@ -1,0 +1,3 @@
+<template>
+  <p class="font-FiraCode flex text-primary-color text-2xl font-semibold sm:text-4xl">> <slot /></p>
+</template>

--- a/components/molecules/shared/SectionLabel.vue
+++ b/components/molecules/shared/SectionLabel.vue
@@ -1,0 +1,6 @@
+<template>
+  <div class="flex">
+    <AtomsSharedTextSectionLabel>About_me</AtomsSharedTextSectionLabel>
+    <!-- <AtomsSharedLinePrimary /> -->
+  </div>
+</template>

--- a/components/molecules/shared/SectionLabel.vue
+++ b/components/molecules/shared/SectionLabel.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex">
+  <div class="flex items-center gap-6">
     <AtomsSharedTextSectionLabel>About_me</AtomsSharedTextSectionLabel>
-    <!-- <AtomsSharedLinePrimary /> -->
+    <AtomsSharedLinePrimary direction="right"/>
   </div>
 </template>

--- a/components/organism/Hero.vue
+++ b/components/organism/Hero.vue
@@ -25,4 +25,5 @@
     </div>
     <MoleculesHeroCarousel />
   </section>
+  <MoleculesSharedSectionLabel />
 </template>

--- a/components/organism/Hero.vue
+++ b/components/organism/Hero.vue
@@ -25,5 +25,4 @@
     </div>
     <MoleculesHeroCarousel />
   </section>
-  <MoleculesSharedSectionLabel />
 </template>


### PR DESCRIPTION
This pull request introduces several changes to the styling and structure of components in the project. The most important changes include the addition of new CSS variables, updates to the `Line-Primary.vue` component to support different gradient directions, and the creation of new section label components.

Styling updates:

* [`assets/css/globals.css`](diffhunk://#diff-2c231a8145e81432851054af24387a53f46c49340dd07c95f6f5522660166453R50): Added a new CSS variable `--text-4.5xl` for a font size of 2.5rem.

Component updates:

* [`components/atoms/shared/Line-Primary.vue`](diffhunk://#diff-107ff44cef6cc4f4e484d5b58434a73363baa8e2579776f3a3a4fe5844f14a16L2-R32): Updated the component to support different gradient directions (`right`, `left`, `both`) and added a `borderWidth` prop for customizable line thickness.
* [`components/atoms/shared/Text_SectionLabel.vue`](diffhunk://#diff-f9c942f59f97991f52830a617c8927c63bc37b7806376447a6c1f96704d883d6R1-R3): Added a new component for section labels with specific styling using the `FiraCode` font and responsive text sizes.
* [`components/molecules/shared/SectionLabel.vue`](diffhunk://#diff-7eb27ca5e0431c3aef464470287b0443dea3cf50199506d1c2dd051544aeda0fR1-R6): Added a new component that combines the `Text_SectionLabel` and `Line-Primary` components to create a labeled section header with a right-aligned gradient line.